### PR TITLE
add AdditionalInfo struct

### DIFF
--- a/submit.go
+++ b/submit.go
@@ -40,9 +40,31 @@ type Payload struct {
 
 // Track is a helper struct for marshalling the JSON payload
 type Track struct {
-	Title  string `json:"track_name"`
-	Artist string `json:"artist_name"`
-	Album  string `json:"release_name"`
+	Title          string `json:"track_name"`
+	Artist         string `json:"artist_name"`
+	Album          string `json:"release_name"`
+	AdditionalInfo `json:"additional_info"`
+}
+
+type AdditionalInfo struct {
+	ArtistMbid              []string `json:"artist_mbids"`
+	ReleaseGroupMbid        string   `json:"release_group_mbid"`
+	ReleaseMbid             string   `json:"release_mbid"`
+	RecordingMbid           string   `json:"recording_mbid"`
+	TrackMbid               string   `json:"track_mbid"`
+	WorkMbids               []string `json:"work_mbids"`
+	Tracknumber             []string `json:"tracknumber"`
+	Isrc                    string   `json:"isrc"`
+	SpotifyId               string   `json:"spotify_id"`
+	Tags                    []string `json:"tags"`
+	MediaPlayer             string   `json:"media_player"`
+	MediaPlayerVersion      string   `json:"media_player_version"`
+	SubmissionClient        string   `json:"submission_client"`
+	SubmissionClientVersion string   `json:"submission_client_version"`
+	MusicService            string   `json:"music_service"`
+	MusicServiceName        string   `json:"music_service_name"`
+	OriginUrl               string   `json:"origin_url"`
+	DurationMs              *int64   `json:"duration_ms,omitempty"`
 }
 
 // FormatPlayingNow formats a Track as a playing_now Submission.

--- a/submit_test.go
+++ b/submit_test.go
@@ -42,10 +42,21 @@ func TestGetSubmissionTime(t *testing.T) {
 }
 
 func TestFormatPlayingNow(t *testing.T) {
+	additional_info := AdditionalInfo{
+		MediaPlayer:             "Rythembox",
+		SubmissionClient:        "Rhythmbox ListenBrainz Plugin",
+		SubmissionClientVersion: "1.0",
+		ReleaseMbid:             "bf9e91ea-8029-4a04-a26a-224e00a83266",
+		ArtistMbid:              []string{"db92a151-1ac2-438b-bc43-b82e149ddd50"},
+		RecordingMbid:           "98255a8c-017a-4bc7-8dd6-1fa36124572b",
+		Tags:                    []string{"you", "just", "got", "rick", "rolled!"},
+		DurationMs:              222000,
+	}
 	track := Track{
-		Title:  "b",
-		Artist: "a",
-		Album:  "c",
+		Title:          "b",
+		Artist:         "a",
+		Album:          "c",
+		AdditionalInfo: additional_info,
 	}
 
 	ts := Submission{


### PR DESCRIPTION
this adds the `AdditionalInfo` struct, documented here: https://listenbrainz.readthedocs.io/en/latest/users/json.html

`duration_ms` could also be included as `duration` - I didn't include that for now because I guess it'd also require some sort of check to enforce mutual exclusivity.